### PR TITLE
[14] Add shop page

### DIFF
--- a/app/pages/(about)/shop.vue
+++ b/app/pages/(about)/shop.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+// Set page metadata
+useSeoMeta({
+  title: 'Shop - Lungmen Dragons',
+  description: 'Browse and purchase items from the Lungmen Dragons official shop.',
+})
+
+// Track iframe height
+const iframeHeight = ref('800px')
+
+// Define the message handler function so we can properly remove it
+const handleMessage = (event: MessageEvent) => {
+  // Check if it's our resize message
+  if (event.data && event.data.type === 'resize-iframe') {
+    // Add a small buffer to avoid cutting off content
+    iframeHeight.value = `${event.data.height + 20}px`
+  }
+}
+
+// Listen for messages from the iframe
+onMounted(() => {
+  window.addEventListener('message', handleMessage)
+})
+
+// Clean up event listener
+onBeforeUnmount(() => {
+  window.removeEventListener('message', handleMessage)
+})
+</script>
+
+<template>
+  <div class="shop-page-container">
+    <div class="shop-header">
+      <h1>Lungmen Dragons Shop</h1>
+      <p>Support us by purchasing official merchandise!</p>
+    </div>
+    
+    <div class="shop-iframe-container">
+      <iframe
+        :src="'/kofi-embed.html'"
+        :style="{ height: iframeHeight }"
+        class="kofi-shop-iframe"
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+        scrolling="no"
+        title="Lungmen Dragons Shop"
+      ></iframe>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.shop-page-container {
+  max-width: 100%;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.shop-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.shop-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #ff5f83;
+  line-height: 1.2;
+}
+
+.shop-header p {
+  font-size: 1.2rem;
+  color: #666;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+.shop-iframe-container {
+  width: 100%;
+  margin: 0 auto;
+  position: relative;
+}
+
+.kofi-shop-iframe {
+  width: 100%;
+  border: none;
+  transition: height 0.3s ease;
+}
+
+/* Responsive width adjustments */
+@media (max-width: 1200px) {
+  .shop-iframe-container {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .shop-header h1 {
+    font-size: 2rem;
+  }
+  
+  .shop-header p {
+    font-size: 1rem;
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .shop-page-container {
+    padding: 0.5rem;
+  }
+  
+  .shop-header h1 {
+    font-size: 1.8rem;
+  }
+  
+  .shop-header p {
+    font-size: 0.95rem;
+  }
+}
+</style>

--- a/app/utils/menu.ts
+++ b/app/utils/menu.ts
@@ -2,6 +2,7 @@ import CarbonEarthFilled from "~icons/carbon/earth-filled";
 import HeroiconsBookOpen from "~icons/heroicons/book-open";
 import HeroiconsBookmark from "~icons/heroicons/bookmark";
 import HeroiconsPuzzlePiece from "~icons/heroicons/puzzle-piece";
+import HeroiconsShoppingBag from "~icons/heroicons/shopping-bag";
 import HeroiconsStar from "~icons/heroicons/star";
 import HeroiconsTrophy from "~icons/heroicons/trophy";
 import HeroiconsWrenchScrewdriver from "~icons/heroicons/wrench-screwdriver";
@@ -125,6 +126,15 @@ function sidebarMenuMain(linkComponent: Component): MenuOption[] {
           icon: renderIcon(CarbonEarthFilled),
           disabled: true,
           // extra: "[WIP]",
+        },
+        {
+          label: () => h(
+            linkComponent,
+            { to: "/shop" },
+            () => "Shop",
+          ),
+          key: "shop",
+          icon: renderIcon(HeroiconsShoppingBag),
         },
         {
           label: () => h(

--- a/public/kofi-embed.html
+++ b/public/kofi-embed.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline' cdn.ko-fi.tools; script-src 'self' 'unsafe-inline' cdn.ko-fi.tools; img-src 'self' data: cdn.ko-fi.tools s3.ko-fi.com storage.ko-fi.com https:; font-src 'self' data:; connect-src 'self' ko-fi.com api.ko-fi.tools; frame-src 'self';">
+  <title>Ko-fi Shop Embed</title>
+  <script defer src="https://cdn.ko-fi.tools/v2/js/shop.js"></script>
+  <style>
+  body {
+    margin: 0;
+    padding: 0;
+    overflow-y: hidden; /* Hide vertical scrollbar */
+    width: 100%;
+  }
+  
+  #kofi-shop-embed {
+    width: 100%;
+    max-width: 100%;
+  }
+  
+  /* Make Ko-fi elements responsive */
+  .kofi-shop-items {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 1rem;
+    width: 100%;
+  }
+</style>
+</head>
+<body>
+  
+  <!-- Ko-fi Shop Embed Widget -->
+  <div id="kofi-shop-embed"
+       data-shop-id="G2G511DGSY"
+       data-shop-currency="$"
+       data-shop-theme="default"
+       data-shop-soldout="show">
+  </div>
+
+  <script>
+    // Function to send height to parent
+    function updateParentHeight() {
+      const height = document.body.scrollHeight;
+      window.parent.postMessage({ type: 'resize-iframe', height: height }, '*');
+    }
+
+    // Create MutationObserver to watch for content changes
+    const observer = new MutationObserver(function() {
+      updateParentHeight();
+    });
+
+    // Observe the entire document for changes
+    observer.observe(document.body, { 
+      childList: true, 
+      subtree: true,
+      attributes: true,
+      characterData: true 
+    });
+
+    // Update height on load and periodically
+    window.addEventListener('load', updateParentHeight);
+    window.addEventListener('DOMContentLoaded', updateParentHeight);
+    
+    // Periodically check height for dynamic content loading
+    setInterval(updateParentHeight, 1000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Adds #14 

Uses iframe as to handle issue with how swaping layouts work in Vuejs, as applicable to the responsive design via media queries. 

It destroys and rebuilts the components. Since the Ko-fi.tools embed is injected through an external script, once the media query swaps the layout, e.g., from desktop to mobile the embed disappears. Having an iframe ensures it keeps being rebuilt, since the initial embed script is loaded from elsewhere.

Code can be optimized. Rushed deployment in time for Canada Fan Expo, from August 21 to 24, 2025.